### PR TITLE
Add CSS to desktop

### DIFF
--- a/desktop/index.html
+++ b/desktop/index.html
@@ -8,5 +8,40 @@
     <link rel="stylesheet" href="style.css" />
     <title>Fluffy Guacamole Desktop</title>
   </head>
-  <body></body>
+  <body>
+    <main>
+      <menu class="menu-main">
+        <div class="btn">🏠</div>
+        <div class="btn">⬆⬇</div>
+        <div class="btn">⚙</div>
+      </menu>
+
+      <section class="library">
+        <div class="book">BOOK COVER</div>
+        <!-- (un)comment below to see the overflow -->
+        <!-- <div class="book">BOOK</div>
+        <div class="book">BOOK</div>
+        <div class="book">BOOK</div>
+        <div class="book">BOOK</div>
+        <div class="book">BOOK</div>
+        <div class="book">BOOK</div>
+        <div class="book">BOOK</div>
+        <div class="book">BOOK</div>
+        <div class="book">BOOK</div>
+        <div class="book">BOOK</div>
+        <div class="book">BOOK</div>
+        <div class="book">BOOK</div>
+        <div class="book">BOOK</div>
+        <div class="book">BOOK</div>
+        <div class="book">BOOK</div>
+        <div class="book">BOOK</div>
+        <div class="book">BOOK</div>
+        <div class="book">BOOK</div>
+        <div class="book">BOOK</div>
+        <div class="book">BOOK</div>
+        <div class="book">BOOK</div> -->
+      </section>
+      <div class="btn btn-add">➕</div>
+    </main>
+  </body>
 </html>

--- a/desktop/index.html
+++ b/desktop/index.html
@@ -11,13 +11,15 @@
   <body>
     <main>
       <menu class="menu-main">
-        <div class="btn">🏠</div>
-        <div class="btn">⬆⬇</div>
-        <div class="btn">⚙</div>
+        <ion-icon class="btn" name="home-outline"></ion-icon>
+        <ion-icon class="btn" name="funnel-outline"></ion-icon>
+        <ion-icon class="btn" name="cog-outline"></ion-icon>
       </menu>
 
       <section class="library">
-        <div class="book">BOOK COVER</div>
+        <div class="book">
+          <ion-icon name="search-outline"></ion-icon>BOOK COVER
+        </div>
         <!-- (un)comment below to see the overflow -->
         <!-- <div class="book">BOOK</div>
         <div class="book">BOOK</div>
@@ -41,7 +43,15 @@
         <div class="book">BOOK</div>
         <div class="book">BOOK</div> -->
       </section>
-      <div class="btn btn-add">➕</div>
+      <div class="btn btn-add"><ion-icon name="add-outline"></ion-icon></div>
     </main>
+    <script
+      type="module"
+      src="https://unpkg.com/ionicons@5.5.2/dist/ionicons/ionicons.esm.js"
+    ></script>
+    <script
+      nomodule
+      src="https://unpkg.com/ionicons@5.5.2/dist/ionicons/ionicons.js"
+    ></script>
   </body>
 </html>

--- a/desktop/style.css
+++ b/desktop/style.css
@@ -1,0 +1,52 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+main {
+  background-color: #adb5bd;
+  width: 1000px;
+  height: 800px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+}
+
+.menu-main {
+  font-size: 45px;
+  background-color: #868e96;
+  display: flex;
+  gap: 20px;
+  padding: 2px;
+}
+
+.btn {
+  color: #fff;
+}
+
+.btn-add {
+  position: absolute;
+  right: 40px;
+  bottom: 50px;
+  font-size: 60px;
+}
+
+.library {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  overflow-y: auto;
+}
+
+.book {
+  margin-top: 10px;
+  margin-left: 10px;
+  width: 150px;
+  height: 200px;
+  border: 1px solid;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}


### PR DESCRIPTION
This PR sets the basis for the design. I used emoji for the buttons and moved the add button (the massive plus sign) to the bottom right.

This PR effectively deprecates the design. I'm not sure if we should redo the design file to reflect this.

You can uncomment the divs in the HTML to see how the overflow works once we start generating the HTML with JavaScript. You will see that we have a decent amount of space on the right so we may be able to use that to move the menu to there, perhaps when we start scrolling?